### PR TITLE
Adds widget and icon customization options

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -39,6 +39,7 @@ const LS_KEYS = {
   WIDGET_SIZE_PREFIX: 'widgetSize:',
   GRID_SIZE_X: 'gridSizeX',
   GRID_SIZE_Y: 'gridSizeY',
+  LOCK_MOVEMENT: 'lockMovement',
 };
 
 const SHAPES = [

--- a/constants.js
+++ b/constants.js
@@ -40,6 +40,7 @@ const LS_KEYS = {
   GRID_SIZE_X: 'gridSizeX',
   GRID_SIZE_Y: 'gridSizeY',
   LOCK_MOVEMENT: 'lockMovement',
+  ICON_SIZE: 'iconSize',
 };
 
 const SHAPES = [
@@ -51,5 +52,6 @@ const SHAPES = [
 // グリッド設定
 let GRID_SIZE_X = parseInt(localStorage.getItem(LS_KEYS.GRID_SIZE_X)) || 80;
 let GRID_SIZE_Y = parseInt(localStorage.getItem(LS_KEYS.GRID_SIZE_Y)) || 90;
+let ICON_SIZE = parseInt(localStorage.getItem(LS_KEYS.ICON_SIZE)) || 80;
 const GRID_OFFSET = 20;
 const OVERLAP_THRESHOLD = 800;

--- a/constants.js
+++ b/constants.js
@@ -37,6 +37,8 @@ const LS_KEYS = {
   MEDIA_PLAYER_SHOW_REPEAT: 'mediaPlayerShowRepeat',
   WIDGET_VISIBILITY: 'widgetVisibility',
   WIDGET_SIZE_PREFIX: 'widgetSize:',
+  GRID_SIZE_X: 'gridSizeX',
+  GRID_SIZE_Y: 'gridSizeY',
 };
 
 const SHAPES = [
@@ -46,7 +48,7 @@ const SHAPES = [
 ];
 
 // グリッド設定
-const GRID_SIZE_X = 80;
-const GRID_SIZE_Y = 90;
+let GRID_SIZE_X = parseInt(localStorage.getItem(LS_KEYS.GRID_SIZE_X)) || 80;
+let GRID_SIZE_Y = parseInt(localStorage.getItem(LS_KEYS.GRID_SIZE_Y)) || 90;
 const GRID_OFFSET = 20;
 const OVERLAP_THRESHOLD = 800;

--- a/desktop.css
+++ b/desktop.css
@@ -784,6 +784,7 @@ body.no-blur .modal_overlay {
   gap: var(--space-lg);
   align-items: center;
   width: 380px;
+  pointer-events: auto;
 }
 
 .modal h3 {
@@ -885,6 +886,7 @@ body.no-blur .modal_overlay {
   justify-content: space-between;
   gap: 16px;
   min-height: 48px;
+  pointer-events: auto;
 }
 
 .settings-item-column {
@@ -951,8 +953,14 @@ body.no-blur .modal_overlay {
   background-image:
     linear-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px),
     linear-gradient(90deg, rgba(255, 255, 255, 0.08) 1px, transparent 1px);
-  background-size: 80px 90px;
-  background-position: 20px 20px;
+  background-size: var(--grid-size-x, 80px) var(--grid-size-y, 90px);
+  background-position: var(--grid-offset, 20px) var(--grid-offset, 20px);
+}
+
+/* 位置変更モード中にオーバーレイがポインターイベントを受け取るようにした場合でも、
+   アイコンやウィジェットが操作できるように設定 */
+.appicon, .widget {
+  pointer-events: auto;
 }
 
 #change_widget_position_modal {

--- a/desktop.css
+++ b/desktop.css
@@ -434,8 +434,8 @@ body {
 .appicon {
   text-align: center;
   cursor: pointer;
-  height: 90px;
-  width: 80px;
+  height: var(--icon-size-y, 90px);
+  width: var(--icon-size-x, 80px);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -448,6 +448,14 @@ body {
   touch-action: none;
   user-select: none;
   -webkit-user-select: none;
+}
+
+.appicon > img,
+.appicon > m3e-shape,
+.appicon > .custom-shape-wrapper {
+  width: var(--icon-img-size, 48px);
+  height: var(--icon-img-size, 48px);
+  object-fit: contain;
 }
 
 /* ドラッグ中のスタイル */
@@ -482,7 +490,7 @@ body.no-blur .appicon:hover {
   color: white;
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5), 0 0 8px rgba(0, 0, 0, 0.3);
   text-align: center;
-  font-size: 0.8rem;
+  font-size: var(--icon-font-size, 0.8rem);
   font-weight: 500;
   margin-top: 6px;
   line-height: 1.2;
@@ -495,8 +503,6 @@ body.no-blur .appicon:hover {
 }
 
 .appicon > img {
-  height: 48px;
-  width: 48px;
   object-fit: contain;
   filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.25));
   transition: transform var(--transition-fast), border-radius var(--transition-normal);
@@ -505,8 +511,6 @@ body.no-blur .appicon:hover {
 
 /* Support for m3e-shape wrapper element (slotted img) */
 .appicon > m3e-shape {
-  height: 48px;
-  width: 48px;
   display: inline-block;
 }
 
@@ -1511,11 +1515,6 @@ body.no-blur .folder-drag-clone {
 .add-shape-button:hover {
   background: var(--md-sys-color-surface-container-highest);
   border-style: solid;
-}
-
-.appicon > .custom-shape-wrapper {
-  width: 100%;
-  height: 100%;
 }
 
 .appicon > .custom-shape-wrapper img {

--- a/desktop.js
+++ b/desktop.js
@@ -570,8 +570,10 @@ function enterPositionChangeMode() {
 function updateGridSizeUI() {
   const xSlider = document.getElementById('grid_size_x_slider');
   const ySlider = document.getElementById('grid_size_y_slider');
+  const iconSlider = document.getElementById('icon_size_slider');
   const xValue = document.getElementById('grid_size_x_value');
   const yValue = document.getElementById('grid_size_y_value');
+  const iconValue = document.getElementById('icon_size_value');
   const overlay = document.getElementById('change_widget_position_modal_overlay');
 
   if (xSlider && xValue) {
@@ -584,13 +586,37 @@ function updateGridSizeUI() {
     if (thumb) thumb.value = GRID_SIZE_Y;
     yValue.textContent = GRID_SIZE_Y;
   }
+  if (iconSlider && iconValue) {
+    const thumb = iconSlider.querySelector('m3e-slider-thumb');
+    if (thumb) thumb.value = ICON_SIZE;
+    iconValue.textContent = ICON_SIZE;
+  }
 
   if (overlay) {
     overlay.style.setProperty('--grid-size-x', GRID_SIZE_X + 'px');
     overlay.style.setProperty('--grid-size-y', GRID_SIZE_Y + 'px');
     overlay.style.setProperty('--grid-offset', GRID_OFFSET + 'px');
   }
+  
+  // アイコンサイズを適用
+  document.documentElement.style.setProperty('--icon-size-x', ICON_SIZE + 'px');
+  document.documentElement.style.setProperty('--icon-size-y', (ICON_SIZE + 10) + 'px'); // 少し高めに設定
+  document.documentElement.style.setProperty('--icon-img-size', (ICON_SIZE * 0.6) + 'px');
+  document.documentElement.style.setProperty('--icon-font-size', Math.max(0.6, Math.min(1.2, ICON_SIZE / 80 * 0.8)) + 'rem');
 }
+
+// アイコンサイズスライダーのイベント
+document.getElementById('icon_size_slider')?.addEventListener('input', (e) => {
+  const newValue = parseInt(e.target.value || e.target.querySelector('m3e-slider-thumb')?.value || 80);
+  ICON_SIZE = newValue;
+  document.getElementById('icon_size_value').textContent = newValue;
+  updateGridSizeUI();
+});
+
+document.getElementById('icon_size_slider')?.addEventListener('change', (e) => {
+  const newValue = parseInt(e.target.value || e.target.querySelector('m3e-slider-thumb')?.value || 80);
+  localStorage.setItem(LS_KEYS.ICON_SIZE, newValue);
+});
 
 /**
  * すべてのアイテムを現在のグリッドにスナップさせる

--- a/desktop.js
+++ b/desktop.js
@@ -529,6 +529,7 @@ function enterPositionChangeMode() {
   // グリッドモードのスイッチの状態を復元
   window.isGridModeEnabled = localStorage.getItem(LS_KEYS.GRID_MODE_ENABLED) === 'true';
   updateGridModeSwitch();
+  updateGridSizeUI();
   
   // グリッド線の表示/非表示
   if (window.isGridModeEnabled) {
@@ -537,6 +538,73 @@ function enterPositionChangeMode() {
     document.getElementById('change_widget_position_modal_overlay').classList.remove('grid-mode');
   }
 }
+
+/**
+ * グリッド設定のUIとCSS変数を更新
+ */
+function updateGridSizeUI() {
+  const xSlider = document.getElementById('grid_size_x_slider');
+  const ySlider = document.getElementById('grid_size_y_slider');
+  const xValue = document.getElementById('grid_size_x_value');
+  const yValue = document.getElementById('grid_size_y_value');
+  const overlay = document.getElementById('change_widget_position_modal_overlay');
+
+  if (xSlider && xValue) {
+    const thumb = xSlider.querySelector('m3e-slider-thumb');
+    if (thumb) thumb.value = GRID_SIZE_X;
+    xValue.textContent = GRID_SIZE_X;
+  }
+  if (ySlider && yValue) {
+    const thumb = ySlider.querySelector('m3e-slider-thumb');
+    if (thumb) thumb.value = GRID_SIZE_Y;
+    yValue.textContent = GRID_SIZE_Y;
+  }
+
+  if (overlay) {
+    overlay.style.setProperty('--grid-size-x', GRID_SIZE_X + 'px');
+    overlay.style.setProperty('--grid-size-y', GRID_SIZE_Y + 'px');
+    overlay.style.setProperty('--grid-offset', GRID_OFFSET + 'px');
+  }
+}
+
+/**
+ * すべてのアイテムを現在のグリッドにスナップさせる
+ */
+function reSnapAllToGrid() {
+  if (!window.isGridModeEnabled) return;
+  document.querySelectorAll(".appicon,.widget").forEach(item => {
+    const currentLeft = item.offsetLeft;
+    const currentTop = item.offsetTop;
+    item.style.position = 'absolute';
+    item.style.left = snapToGrid(currentLeft, 'x') + 'px';
+    item.style.top = snapToGrid(currentTop, 'y') + 'px';
+  });
+}
+
+// グリッドサイズスライダーのイベント
+document.getElementById('grid_size_x_slider')?.addEventListener('input', (e) => {
+  const newValue = parseInt(e.target.value || e.target.querySelector('m3e-slider-thumb')?.value || 80);
+  GRID_SIZE_X = newValue;
+  document.getElementById('grid_size_x_value').textContent = newValue;
+  updateGridSizeUI();
+});
+
+document.getElementById('grid_size_x_slider')?.addEventListener('change', (e) => {
+  const newValue = parseInt(e.target.value || e.target.querySelector('m3e-slider-thumb')?.value || 80);
+  localStorage.setItem(LS_KEYS.GRID_SIZE_X, newValue);
+});
+
+document.getElementById('grid_size_y_slider')?.addEventListener('input', (e) => {
+  const newValue = parseInt(e.target.value || e.target.querySelector('m3e-slider-thumb')?.value || 90);
+  GRID_SIZE_Y = newValue;
+  document.getElementById('grid_size_y_value').textContent = newValue;
+  updateGridSizeUI();
+});
+
+document.getElementById('grid_size_y_slider')?.addEventListener('change', (e) => {
+  const newValue = parseInt(e.target.value || e.target.querySelector('m3e-slider-thumb')?.value || 90);
+  localStorage.setItem(LS_KEYS.GRID_SIZE_Y, newValue);
+});
 
 // 位置変更モードを終了する（保存または閉じる時に呼ばれる）
 function exitPositionChangeMode() {
@@ -637,19 +705,7 @@ if (gridModeSwitch) {
       overlay.classList.remove('grid-mode');
     }
     
-    // グリッドモードが有効になったら、すべてのアイコンの位置をグリッドにスナップ
-    if (window.isGridModeEnabled) {
-      document.querySelectorAll(".appicon,.widget").forEach(item => {
-        // 現在の位置を取得（absoluteでない場合はoffsetLeftを使用）
-        const currentLeft = item.offsetLeft;
-        const currentTop = item.offsetTop;
-        
-        // グリッドにスナップ
-        item.style.position = 'absolute';
-        item.style.left = snapToGrid(currentLeft, 'x') + 'px';
-        item.style.top = snapToGrid(currentTop, 'y') + 'px';
-      });
-    }
+    // 自動スナップは行わない（ユーザーの操作を尊重）
   });
 }
 
@@ -916,6 +972,7 @@ const initWindowCountSelector = window.SystemSettingsManager.initWindowCountSele
 
 // 初期化実行
 initWindowCountSelector();
+updateGridSizeUI();
 
 // ディスプレイセレクターの初期化
 const initDisplaySelector = window.SystemSettingsManager.initDisplaySelector.bind(window.SystemSettingsManager);

--- a/desktop.js
+++ b/desktop.js
@@ -397,11 +397,36 @@ document.getElementById('close_settingsmenu_modal').onclick = () => {
 // ========================================
 
 window.isGridModeEnabled = localStorage.getItem(LS_KEYS.GRID_MODE_ENABLED) === 'true';
+window.isMovementLocked = localStorage.getItem(LS_KEYS.LOCK_MOVEMENT) === 'true';
 window.isPositionChangeMode = false;
 window.draggedItem = null;
 window.folders = JSON.parse(localStorage.getItem(LS_KEYS.APP_FOLDERS) || '{}');
 window.currentOpenFolderId = null;
 window.currentFolderPage = 0;
+
+function updateLockMovementUI() {
+  const toggle = document.getElementById('toggle_lock_movement_position_modal');
+  if (toggle) {
+    if (typeof toggle.selected !== 'undefined') {
+      toggle.selected = window.isMovementLocked;
+    } else {
+      toggle.checked = window.isMovementLocked;
+    }
+  }
+}
+
+// 初期化時にUIを更新
+updateLockMovementUI();
+
+// トグルイベントの設定
+const lockMovementToggle = document.getElementById('toggle_lock_movement_position_modal');
+if (lockMovementToggle) {
+  lockMovementToggle.addEventListener('change', (e) => {
+    const newState = typeof e.target.selected !== 'undefined' ? e.target.selected : e.target.checked;
+    window.isMovementLocked = newState;
+    localStorage.setItem(LS_KEYS.LOCK_MOVEMENT, newState);
+  });
+}
 
 // ドラッグ開始判定に使う閾値（ピクセル）
 const DRAG_THRESHOLD = 8;

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -54,9 +54,9 @@
   "refresh_dev": "Refresh (dev)",
   "grid_mode": "Grid Mode",
   "grid_size_x": "Grid Width (X)",
-  "grid_size_y": "Grid Height (Y)",
-  "save_change_position": "Save Positions",
-  "reset_positions_confirm": "Reset all widget and icon positions?",
+      "grid_size_y": "Grid Height (Y)",
+      "icon_size": "Icon Size",
+      "save_change_position": "Save Positions",  "reset_positions_confirm": "Reset all widget and icon positions?",
 
   "general": "General",
   "keyboard_shortcuts": "Keyboard Shortcuts",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -68,6 +68,7 @@
   "about": "About",
 
   "language": "Language",
+  "lock_movement": "Lock Movement",
   "color_scheme": "Color Scheme",
   "dark_mode": "Dark Mode",
   "light_mode": "Light Mode",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -53,6 +53,8 @@
   "reset_position": "Reset Positions",
   "refresh_dev": "Refresh (dev)",
   "grid_mode": "Grid Mode",
+  "grid_size_x": "Grid Width (X)",
+  "grid_size_y": "Grid Height (Y)",
   "save_change_position": "Save Positions",
   "reset_positions_confirm": "Reset all widget and icon positions?",
 

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -53,6 +53,8 @@
   "reset_position": "位置をリセット",
   "refresh_dev": "リフレッシュ(開発者向け)",
   "grid_mode": "グリッドモード",
+  "grid_size_x": "グリッド幅 (X)",
+  "grid_size_y": "グリッド高さ (Y)",
   "save_change_position": "位置を保存",
   "reset_positions_confirm": "すべてのウィジェットとアイコンの位置をリセットしますか？",
 

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -54,9 +54,9 @@
   "refresh_dev": "リフレッシュ(開発者向け)",
   "grid_mode": "グリッドモード",
   "grid_size_x": "グリッド幅 (X)",
-  "grid_size_y": "グリッド高さ (Y)",
-  "save_change_position": "位置を保存",
-  "reset_positions_confirm": "すべてのウィジェットとアイコンの位置をリセットしますか？",
+      "grid_size_y": "グリッド高さ (Y)",
+      "icon_size": "アイコンのサイズ",
+      "save_change_position": "位置を保存",  "reset_positions_confirm": "すべてのウィジェットとアイコンの位置をリセットしますか？",
 
   "general": "一般",
   "keyboard_shortcuts": "キーボードショートカット",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -68,6 +68,7 @@
   "about": "バージョン情報",
 
   "language": "言語",
+  "lock_movement": "移動をロック",
   "color_scheme": "カラースキーム",
   "dark_mode": "ダークモード",
   "light_mode": "ライトモード",

--- a/index.html
+++ b/index.html
@@ -526,6 +526,12 @@
             <m3e-slider-thumb value="90"></m3e-slider-thumb>
           </m3e-slider>
         </div>
+        <div class="settings-item" style="width: 100%;">
+          <div class="settings-item-label">
+            <span data-i18n="lock_movement">移動をロック</span>
+          </div>
+          <m3e-switch id="toggle_lock_movement_position_modal"></m3e-switch>
+        </div>
         <m3e-button variant="filled" id="save_change_widget_position" data-i18n="save">保存</m3e-button>
         <m3e-button variant="filled" id="reset_widget_position" data-i18n="reset_position">位置をリセット</m3e-button>
       </div>

--- a/index.html
+++ b/index.html
@@ -510,6 +510,22 @@
           </div>
           <m3e-switch id="toggle_grid_mode"></m3e-switch>
         </div>
+        <div class="settings-item" style="width: 100%; flex-direction: column; align-items: flex-start; gap: 8px;">
+          <div class="settings-item-label">
+            <span data-i18n="grid_size_x">グリッド幅 (X)</span>: <span id="grid_size_x_value">80</span>px
+          </div>
+          <m3e-slider id="grid_size_x_slider" min="40" max="200" step="1" style="width: 100%; pointer-events: auto;">
+            <m3e-slider-thumb value="80"></m3e-slider-thumb>
+          </m3e-slider>
+        </div>
+        <div class="settings-item" style="width: 100%; flex-direction: column; align-items: flex-start; gap: 8px;">
+          <div class="settings-item-label">
+            <span data-i18n="grid_size_y">グリッド高さ (Y)</span>: <span id="grid_size_y_value">90</span>px
+          </div>
+          <m3e-slider id="grid_size_y_slider" min="40" max="200" step="1" style="width: 100%; pointer-events: auto;">
+            <m3e-slider-thumb value="90"></m3e-slider-thumb>
+          </m3e-slider>
+        </div>
         <m3e-button variant="filled" id="save_change_widget_position" data-i18n="save">保存</m3e-button>
         <m3e-button variant="filled" id="reset_widget_position" data-i18n="reset_position">位置をリセット</m3e-button>
       </div>

--- a/index.html
+++ b/index.html
@@ -526,6 +526,14 @@
             <m3e-slider-thumb value="90"></m3e-slider-thumb>
           </m3e-slider>
         </div>
+        <div class="settings-item" style="width: 100%; flex-direction: column; align-items: flex-start; gap: 8px;">
+          <div class="settings-item-label">
+            <span data-i18n="icon_size">アイコンのサイズ</span>: <span id="icon_size_value">80</span>px
+          </div>
+          <m3e-slider id="icon_size_slider" min="40" max="160" step="1" style="width: 100%; pointer-events: auto;">
+            <m3e-slider-thumb value="80"></m3e-slider-thumb>
+          </m3e-slider>
+        </div>
         <div class="settings-item" style="width: 100%;">
           <div class="settings-item-label">
             <span data-i18n="lock_movement">移動をロック</span>

--- a/modules/drag_manager.js
+++ b/modules/drag_manager.js
@@ -159,7 +159,7 @@ window.DragManager = {
     });
 
     item.onpointerdown = function(event) {
-      if (event.button !== 0) return;
+      if (event.button !== 0 || window.isMovementLocked) return;
       this.setPointerCapture(event.pointerId);
       this._isDragging = false;
       this._startX = event.clientX; this._startY = event.clientY;
@@ -229,7 +229,7 @@ window.DragManager = {
     }
 
     item.onpointerdown = function(event) {
-      if (event.button !== 0) return;
+      if (event.button !== 0 || window.isMovementLocked) return;
       this.setPointerCapture(event.pointerId);
       this._isDragging = false;
       this._startX = event.clientX; this._startY = event.clientY;


### PR DESCRIPTION
Adds functionality to customize the grid size, icon size, and movement locking for widgets and apps on the desktop.

- Introduces grid size customization, allowing users to adjust the grid width and height via sliders in the settings modal.
- Implements icon size customization, enabling users to modify the size of app icons through a slider.
- Adds a lock movement toggle to prevent accidental dragging of icons and widgets.

These features enhance the user's ability to personalize their desktop environment.